### PR TITLE
#115 particle unit tests with `extern` implementation discussed in #130

### DIFF
--- a/Common/src/main.cpp
+++ b/Common/src/main.cpp
@@ -175,8 +175,10 @@ void setup()
 #endif
 
   //Sensors Initializers go here.
-
   Serial.println("Setup Done!\n");
+#if PARTICLE_UNIT_TESTS
+  tests();
+#endif
 }
 
 void loop()

--- a/Particle/.vscode/settings.json
+++ b/Particle/.vscode/settings.json
@@ -7,6 +7,6 @@
         "chrono": "cpp",
         "thread": "cpp"
     },
-    "particle.firmwareVersion": "3.0.0-rc.2",
+    "particle.firmwareVersion": "3.0.0-rc.1",
     "particle.targetPlatform": "boron"
 }

--- a/Particle/src/PinConfig.h
+++ b/Particle/src/PinConfig.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "platforms.h"
 
 
 #define ERTC        1
@@ -83,4 +84,10 @@
 #define FLOW_PIN     A3
 #define SDCARD_SELECT_PIN  SCK
 #define MAX_V 3.3
+#endif
+
+#define PARTICLE_UNIT_TESTS 0
+
+#if PARTICLE_UNIT_TESTS
+#include "tests/tests.h"
 #endif

--- a/Particle/src/tests/tests.cpp
+++ b/Particle/src/tests/tests.cpp
@@ -1,0 +1,7 @@
+#include "PinConfig.h"
+#include <Arduino.h>
+
+void tests() {
+Serial.println("Hello Unit Tests");
+
+}

--- a/Particle/src/tests/tests.cpp
+++ b/Particle/src/tests/tests.cpp
@@ -1,7 +1,8 @@
 #include "PinConfig.h"
 #include <Arduino.h>
+#include "tests.h"
 
 void tests() {
-Serial.println("Hello Unit Tests");
-
+    Serial.println("Hello Unit Tests");
+    while(1);
 }

--- a/Particle/src/tests/tests.cpp
+++ b/Particle/src/tests/tests.cpp
@@ -1,8 +1,16 @@
-#include "PinConfig.h"
-#include <Arduino.h>
 #include "tests.h"
 
 void tests() {
     Serial.println("Hello Unit Tests");
+    // Test that extern objects are available
+    Serial.printlnf("%s", rtc.getTimeStamp().c_str());
     while(1);
+}
+
+void printTestStart(String tag) {
+    Serial.printlnf("----- START OF %s TEST -----", tag.c_str());
+}
+
+void printTestEnd(String tag) {
+    Serial.printlnf("------ END OF %s TEST ------", tag.c_str());
 }

--- a/Particle/src/tests/tests.h
+++ b/Particle/src/tests/tests.h
@@ -1,0 +1,1 @@
+void tests();

--- a/Particle/src/tests/tests.h
+++ b/Particle/src/tests/tests.h
@@ -1,1 +1,41 @@
-void tests();
+#include "PinConfig.h"
+#include <Arduino.h>
+
+#if EN_GSM
+#include "Gsm.h"
+extern Gsm gsm;
+#endif
+
+#if CURRENT
+#include "Current.h"
+extern Current hall_effect;
+#endif
+
+#if VOLTAGE
+#include "Voltage.h"
+extern Voltage volt_divider;
+#endif
+
+#if TEMPERATURE
+#include "Temperature.h"
+extern Temperature thermocouple; //pretty slow response and depends greatly on the surface temperature of the thermocouple tip
+#endif
+
+#if FLOW
+#include "Flow.h"
+extern Flow waterflow;
+#endif
+
+#if ERTC
+#include "RealTimeClock.h"
+extern RealTimeClock rtc;
+#endif
+
+#if SDCARD
+#include "SdCard.h"
+extern SdCard memory;
+#endif
+
+void tests(); 
+void printTestStart(String tag);
+void printTestEnd(String tag);


### PR DESCRIPTION
Use `extern` keyword to access object instances created in `main.cpp` in `tests.h`. Uses `PinConfig.h` checks to decide which classes to include with extern. 

This PR includes changes to the particle testing framework discussed in issue #130 